### PR TITLE
Migration to Now 2.0

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,12 +31,11 @@ const manifest = {
 module.exports = withCSS(
   withManifest(
     withOffline({
-      target: "server",
       manifest,
       workboxOpts: {
         swDest: path.join(__dirname, "public/service-worker.js"),
       },
-      publicRuntimeConfig: {
+      env: {
         // Will be available on both server and client
         DROPBOX_APP_KEY: process.env.DROPBOX_APP_KEY,
         DROPBOX_APP_SECRET: process.env.DROPBOX_APP_SECRET,

--- a/now.json
+++ b/now.json
@@ -1,15 +1,14 @@
 {
   "name": "chartcomposer",
-  "alias": ["chartcomposer.com", "songdocs.io"],
   "github": {
     "enabled": true,
     "autoAlias": true
   },
-  "version": 1,
-  "regions": ["sfo1"],
-  "env": {
-    "DROPBOX_APP_KEY": "@dropbox_app_key",
-    "DROPBOX_APP_SECRET": "@dropbox_app_secret",
-    "DROPBOX_PUBLIC_TOKEN": "@dropbox_public_token"
+  "build": {
+    "env": {
+      "DROPBOX_APP_KEY": "@dropbox_app_key",
+      "DROPBOX_APP_SECRET": "@dropbox_app_secret",
+      "DROPBOX_PUBLIC_TOKEN": "@dropbox_public_token"
+    }
   }
 }

--- a/now.json
+++ b/now.json
@@ -1,5 +1,5 @@
 {
-  "name": "chartcomposer",
+  "name": "chartcomposer-static",
   "github": {
     "enabled": true,
     "autoAlias": true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dev": "NODE_ENV=development next dev",
     "start": "NODE_ENV=production next start",
     "deploy": "now --team chartcomposer --token=$NOW_TOKEN",
-    "alias": "now alias --team chartcomposer --token=$NOW_TOKEN",
     "dev_server": "NODE_ENV=development node server/server.js",
     "start_server": "NODE_ENV=production node server/server.js"
   },
@@ -52,6 +51,6 @@
     "eslint-plugin-react": "^7.14.2",
     "jest": "^25.0.0",
     "load-script": "^1.0.0",
-    "now": "^11.4.6"
+    "now": "latest"
   }
 }

--- a/pages/authreceiver.js
+++ b/pages/authreceiver.js
@@ -51,9 +51,6 @@ class AuthReceiverPage extends React.Component {
 }
 
 class AuthReceiverPageWrapper extends React.Component {
-  static async getInitialProps() {
-    return {};
-  }
   render() {
     return (
       <Page>

--- a/pages/index.js
+++ b/pages/index.js
@@ -522,10 +522,6 @@ class IndexPage extends React.Component {
 }
 
 class IndexPageWrapper extends React.Component {
-  static async getInitialProps() {
-    return {};
-  }
-
   render() {
     return (
       <Page>


### PR DESCRIPTION
This is the first draft of the migration. Useful changes:

- `publicRuntimeConfig` to `env`. As described in https://github.com/zeit/next.js/#build-time-configuration.
- Removed unnecessary configuration from Now.json. You will need to add the domain as a production domain: https://zeit.co/docs/v2/custom-domains
- Bumped `now` version in `devDependencies`.
- Removed `getInitialProps` since everything can be static and enjoy SmartCDN.